### PR TITLE
Invisible markdown anchors for paxgen (LLM prompt auto-generator).

### DIFF
--- a/pages/key-concepts/components.mdx
+++ b/pages/key-concepts/components.mdx
@@ -1,5 +1,7 @@
 # Components
 
+[//]: # (359630593ac547b4459c5e7bcd7a65c3:start)
+
 The atomic unit of Pax is a `component definition`. A component definition for `MyNewComponent` may look like:
 
 ```rust filename="lib.rs"  copy
@@ -101,6 +103,8 @@ This "components all the way down" pattern may be familiar if you have used a GU
 This is essentially how you define a Pax Component. The only exception is the root component which is signified with the `main` attribute and lives in the root `lib.rs`.
 
 Notice that Pax builds off of Rust's import and namespace resolution mechanisms, so importing `crate::EmptyComponent` to a `.rs` file means that you can use `<EmptyComponent />` inside a template in that file.
+
+[//]: # (359630593ac547b4459c5e7bcd7a65c3:stop)
 
 You can read more about Pax components in the chapter [Hardware Component Model](../reference/hardware-component-model.md).
 <br />

--- a/pages/key-concepts/expressions.mdx
+++ b/pages/key-concepts/expressions.mdx
@@ -1,5 +1,7 @@
 # Expressions
 
+[//]: # (cbe9f37cef36c8fa421f6ca500ac24bf:start)
+
 ```pax copy
 <Rectangle transform={
     rotate(engine.frames_elapsed / 200.0) *
@@ -33,3 +35,5 @@ Because Pax Expressions are pure, side-effect-free functions, the Pax runtime ca
 and only recomputing when one of the stated inputs changes.  Expressions are also readily parallelizable, a prospective future performance optimization.
 
 You can read more about PAXEL, the Pax Expression Language, [in this chapter](../reference/paxel.md).
+
+[//]: # (cbe9f37cef36c8fa421f6ca500ac24bf:stop)

--- a/pages/key-concepts/handlers.mdx
+++ b/pages/key-concepts/handlers.mdx
@@ -13,6 +13,9 @@
   />
   <p>A finger on a touch-screen, emitting lightning where it touches</p>
 </div>
+
+[//]: # (8131d6966a7f9a63c435deaf5b79b664:start)
+
 ```rust
 #[pax(
     <Rectangle @click=self.handle_click>
@@ -117,4 +120,4 @@ Pax supports the following input events:
 - ContextMenu (@context_menu)
 - Wheel (@wheel)
 
-
+[//]: # (8131d6966a7f9a63c435deaf5b79b664:stop)

--- a/pages/key-concepts/primitives.mdx
+++ b/pages/key-concepts/primitives.mdx
@@ -1,5 +1,6 @@
 # Primitives
 
+[//]: # (fb144467945d10ab68f81eda3af4bde3:start)
 
 Primitives are a special case of `component` — with direct access to the engine, runtime, and rendering context.  Primitives are authored in pure Rust, without any Pax language sugar: templates, expressions, or settings.
 
@@ -19,3 +20,5 @@ This complexity is due to Pax's [compilation model](/reference-compilation-model
 One more way to think of the above, through the [NES cartridge model](): Primitives are authored in the context of the _console_ rather than the context of _cartridges_.
 
 Primitives are exposed cartridge-side (e.g. for importing and using `<Group />`) through the `pax_primitive` macro — you can find examples of this in `pax-std/src/lib.rs`.
+
+[//]: # (fb144467945d10ab68f81eda3af4bde3:stop)

--- a/pages/key-concepts/settings.mdx
+++ b/pages/key-concepts/settings.mdx
@@ -19,6 +19,7 @@
 
 Recall that the atomic unit of Pax is the [component](./start-key-concepts-components.md).  Components pass data to each other through `properties` and `settings`.[1]  
 
+[//]: # (1bdb47551ded2905735ab34924507ff0:start)
 
 ## Properties
 
@@ -123,7 +124,7 @@ Ease a property value over time with an easing curve (generally, for animation)
 
 Same as `ease_to`, but enqueues the specified transition to occur after all currently enqueued transitions are completed.
 
-
+[//]: # (1bdb47551ded2905735ab34924507ff0:stop)
 
 ---
 

--- a/pages/key-concepts/templates.mdx
+++ b/pages/key-concepts/templates.mdx
@@ -1,5 +1,7 @@
 # Templates
 
+[//]: # (8a4bfc8b47c07012ebbf0328529e8417:start)
+
 A component's _template_ describes that component's _content_ and _hierarchy_.  
 
 Example template:
@@ -125,3 +127,5 @@ for (elem, i) in self.computed_layout_spec {
     </Frame>
 }
 ```
+
+[//]: # (8a4bfc8b47c07012ebbf0328529e8417:stop)

--- a/pages/reference/layout.md
+++ b/pages/reference/layout.md
@@ -1,5 +1,7 @@
 # Coordinate System & Transforms
 
+[//]: # (9732c66d1335615593249a6e623479a8:start)
+
 Pax's coordinate system is "top-left origin; right is positive x; down is positive y"
 
 <!-- TODO: image illustrating coordinate system -->
@@ -113,6 +115,8 @@ A few important notes about matrix multiplication:
 
 
 Organizationally, you may find that it is useful to combine hierarchical grouping with matrix multiplication in different ways.  You may also make use of helper methods which can return dynamic or pre-computed transformations.  Finally, the use of layout components (such as `pax-std`'s `Stacker`, or components that you may author yourself) allow abstraction of complex positioning and resizing logic.
+
+[//]: # (9732c66d1335615593249a6e623479a8:stop)
 
 --
 

--- a/pages/reference/paxel.md
+++ b/pages/reference/paxel.md
@@ -24,6 +24,8 @@ See [the source code](https://github.com/paxengine/pax/blob/master/pax-lang/src/
 
 ### PAXEL Compilation
 
+[//]: # (62e3c3e1ceb61335e83d631afbbb5080:start)
+
 PAXEL is compiled by transpiling through Rust.  In practice, this is fairly straight-forward — in many cases, PAXEL and Rust are syntactically identical.
 
 PAXEL's scoping mechanism requires special consideration by Pax's compiler — for example, inside a [template `for` loop](../key-concepts/templates.mdx#for), PAXEL can refer to the scoped _predicate declaration_ (e.g. the `i` in `for i in 0..10`). 
@@ -57,6 +59,8 @@ Finally, PAXEL can refer to the symbol representing the type of the Property ass
     }
 }
 ```
+
+[//]: # (62e3c3e1ceb61335e83d631afbbb5080:stop)
 
 With a reasonable and finite amount of work, PAXEL will also be able to refer to "anything within scope" within a Rust file, allowing the import & use of arbitrary symbols & packages.  This approach will build on the `get_type_id` work done by the parser to reflect on Property types.  Until that time, using an arbitrary import — for example, calling an imported method — requires re-exposing that method through a method available on `self`.
 


### PR DESCRIPTION
Add invisible markers (that render to nothing in Markdown) in the Pax docs to delineate the parts to be used as LLM prompts.

To capture arbitrary strings in `pax/scripts/paxgen/paxgen/generate.py`, generate arbitrary unique strings (e.g. hashes) and do in the docs:

```
some text 

[//]: # (9732c66d1335615593249a6e623479a8:start)

some other text

[//]: # (9732c66d1335615593249a6e623479a8:start)

something else
```

which captures `some other text`.

Companion PR: this is a dependency of https://github.com/paxengine/pax/pull/209